### PR TITLE
fix: prevent user enumeration in login error messages

### DIFF
--- a/src/components/LoginPage/LoginPage.jsx
+++ b/src/components/LoginPage/LoginPage.jsx
@@ -45,15 +45,9 @@ const LoginPage = () => {
       toast.success("Login realizado com sucesso!");
       navigate("/dashboard");
     } catch (err) {
-      let errorMessage = "Erro ao fazer login. Verifique suas credenciais.";
-
-      if (err.message) {
-        errorMessage = err.message;
-      } else if (Array.isArray(err)) {
-        errorMessage = err.join(", ");
-      }
-
-      toast.error(errorMessage);
+      // Sempre exibir mensagem genérica para evitar enumeração de usuários
+      // Não revelar se o usuário existe ou se a senha está incorreta
+      toast.error("Credenciais inválidas. Verifique seu usuário e senha.");
     } finally {
       setLoading(false);
     }

--- a/src/components/LoginPage/LoginPage.test.jsx
+++ b/src/components/LoginPage/LoginPage.test.jsx
@@ -336,14 +336,15 @@ describe("LoginPage", () => {
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
-          "Erro ao fazer login. Verifique suas credenciais."
+          "Credenciais inválidas. Verifique seu usuário e senha."
         );
       });
     });
 
-    it("mostra mensagem de erro específica quando disponível", async () => {
-      const errorMessage = "Credenciais inválidas";
-      mockLogin.mockRejectedValue({ message: errorMessage });
+    it("sempre mostra mensagem genérica mesmo quando há mensagem específica (segurança)", async () => {
+      // Por segurança, não devemos revelar se o usuário existe ou se a senha está incorreta
+      const specificErrorMessage = "Usuário não encontrado";
+      mockLogin.mockRejectedValue({ message: specificErrorMessage });
       renderLoginPage();
 
       const usernameInput = screen.getByPlaceholderText(/Nome de usuário/i);
@@ -355,11 +356,17 @@ describe("LoginPage", () => {
       fireEvent.click(loginButton);
 
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(errorMessage);
+        // Sempre deve mostrar mensagem genérica para evitar enumeração de usuários
+        expect(toast.error).toHaveBeenCalledWith(
+          "Credenciais inválidas. Verifique seu usuário e senha."
+        );
+        // Não deve mostrar a mensagem específica
+        expect(toast.error).not.toHaveBeenCalledWith(specificErrorMessage);
       });
     });
 
-    it("trata erro como array de mensagens", async () => {
+    it("sempre mostra mensagem genérica mesmo com array de mensagens (segurança)", async () => {
+      // Por segurança, sempre mostrar mensagem genérica, mesmo com array de erros
       const errorMessages = ["Erro 1", "Erro 2"];
       mockLogin.mockRejectedValue(errorMessages);
       renderLoginPage();
@@ -373,7 +380,10 @@ describe("LoginPage", () => {
       fireEvent.click(loginButton);
 
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith("Erro 1, Erro 2");
+        // Sempre deve mostrar mensagem genérica para evitar enumeração de usuários
+        expect(toast.error).toHaveBeenCalledWith(
+          "Credenciais inválidas. Verifique seu usuário e senha."
+        );
       });
     });
 


### PR DESCRIPTION
Replace specific error messages with generic message to avoid revealing whether username exists or password is incorrect. This prevents attackers from enumerating valid usernames.

Updated tests to verify that generic error message is always shown regardless of backend response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always display a generic login error message and update tests to enforce this behavior.
> 
> - **Frontend**
>   - Standardize login failure handling in `src/components/LoginPage/LoginPage.jsx` to always show `"Credenciais inválidas. Verifique seu usuário e senha."` and remove branching on backend error shapes/messages.
> - **Tests**
>   - Update `src/components/LoginPage/LoginPage.test.jsx` expectations to the generic error.
>   - Add/modify tests to ensure the generic message is shown even when backend returns a specific `message` or an array of errors, and not the specific texts.
>   - Keep validations for re-enabling fields after errors and other existing behaviors intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87435f5608d3bae4c90493c3531ee733b5d35d6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->